### PR TITLE
Correct the path to Strapi's socket when Strapi is served inside a directory

### DIFF
--- a/admin/src/modules/alerts/services/alerts-service.js
+++ b/admin/src/modules/alerts/services/alerts-service.js
@@ -8,7 +8,23 @@ export default class AlertsService {
   _streamIdentifier;
 
   constructor() {
-    this._client = SocketIoClient.connect(process.env.STRAPI_ADMIN_BACKEND_URL);
+    const uri = process.env.STRAPI_ADMIN_BACKEND_URL;
+    let path = '/socket.io'; // SocketIoClient defaults to this path too if it is not defined
+
+    // If uri is not undefined nor empty, use the correct path to Strapi's socket
+    if (uri !== undefined && uri.length > 0) {
+      try {
+        const { pathname } = new URL(
+          uri,
+          window.location.href // Mandatory in case uri is not a complete URL (e.g. /cms)
+        );
+        path = `${pathname}${pathname.endsWith('/') ? '' : '/'}socket.io`;
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    this._client = SocketIoClient.connect(uri, { path });
   }
 
   setStreamIdentifier(streamIdentifier) {


### PR DESCRIPTION
This PR addresses an issue where the plugin fails to connect to Strapi's socket when Strapi is served inside a directory. The solution involves passing the path to Strapi's instance to the socket.io client.

Fixes #54.