### PR TITLE
Refactor lifecycle hooks and document handling

### DIFF
--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -1,66 +1,17 @@
 import type { Core } from '@strapi/strapi';
-import RequestInitiatorHelper from './utils/request-initiator-helper';
 import deepPopulateHook, { DeepPopulateHookEvent } from './lifecycles/deep-populate-hook';
 import { Server } from 'socket.io';
 import { WebSocketServer } from 'ws';
-import uploadEventEntryToLocalazyHook from './lifecycles/upload-event-entry-to-localazy-hook';
-import deprecateEventEntryInLocalazyHook from './lifecycles/deprecate-event-entry-in-localazy-hook';
 
 const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
   // bootstrap phase
   strapi.db.lifecycles.subscribe(async (event) => {
-    const requestInitiatorHelper = new RequestInitiatorHelper(strapi);
     const action = event.action;
     switch (action) {
       case 'beforeFindMany':
       case 'beforeFindOne': {
         deepPopulateHook(event as DeepPopulateHookEvent);
         break;
-      }
-      case 'afterCreate':
-      case 'afterUpdate': {
-        try {
-          if (
-            requestInitiatorHelper.isInitiatedByLocalazyWebhook() ||
-            requestInitiatorHelper.isInitiatedByLocalazyPluginUI()
-          ) {
-            break;
-          }
-
-          uploadEventEntryToLocalazyHook(event).then((result) => {
-            if (typeof result !== 'undefined') {
-              strapi.log.info(`${action} hook result: ${JSON.stringify(result)}`);
-            }
-          });
-        } catch (e) {
-          strapi.log.error(e);
-        } finally {
-          break;
-        }
-      }
-      /**
-       * 'beforeDeleteMany' won't ever be called in Strapi 5
-       * See https://docs.strapi.io/dev-docs/migration/v4-to-v5/breaking-changes/lifecycle-hooks-document-service#breaking-change-description
-       */
-      case 'beforeDelete': {
-        try {
-          if (
-            requestInitiatorHelper.isInitiatedByLocalazyWebhook() ||
-            requestInitiatorHelper.isInitiatedByLocalazyPluginUI()
-          ) {
-            break;
-          }
-
-          // have to await here
-          const result = await deprecateEventEntryInLocalazyHook(event);
-          if (typeof result !== 'undefined') {
-            strapi.log.info(`${action} hook result: ${JSON.stringify(result)}`);
-          }
-        } catch (e) {
-          strapi.log.error(e);
-        } finally {
-          break;
-        }
       }
       default:
         break;

--- a/server/src/lifecycles/deprecate-event-entry-in-localazy-hook.ts
+++ b/server/src/lifecycles/deprecate-event-entry-in-localazy-hook.ts
@@ -3,15 +3,17 @@ import config from '../config';
 import LocalazyApiClientFactory from '../utils/localazy-api-client-factory';
 import { delay } from '../utils/delay';
 import { getLocalazyUserService, getLocalazyPubAPIService } from '../core';
+import { Locales } from '@localazy/api-client';
+import type { HookParams } from '../models/plugin/hook-params';
 
-export default async (event: any) => {
-  const pickedFlattedResult = await getPickedFlattenKeysForHookEntry(event);
+export default async (params: HookParams) => {
+  const pickedFlattedResult = await getPickedFlattenKeysForHookEntry(params);
 
   if (typeof pickedFlattedResult === 'undefined') {
     return;
   }
 
-  const { pickedFlatten, eventEntryLocale } = pickedFlattedResult;
+  const { pickedFlatten, projectSourceLanguageCode } = pickedFlattedResult;
 
   const LocalazyUserService = getLocalazyUserService();
   const LocalazyPubApiService = getLocalazyPubAPIService();
@@ -31,7 +33,7 @@ export default async (event: any) => {
   const projectKeys = await LocalazyApi.files.listKeys({
     project: user.project.id,
     file: strapiFile.id,
-    lang: eventEntryLocale,
+    lang: projectSourceLanguageCode as Locales,
   });
 
   if (!projectKeys) {

--- a/server/src/lifecycles/upload-event-entry-to-localazy-hook.ts
+++ b/server/src/lifecycles/upload-event-entry-to-localazy-hook.ts
@@ -1,9 +1,10 @@
 import getPickedFlattenKeysForHookEntry from '../utils/get-picked-flatten-keys-for-hook-entry';
 import config from '../config';
 import { getLocalazyUploadService } from '../core';
+import type { HookParams } from '../models/plugin/hook-params';
 
-export default async (event: any) => {
-  const pickedFlattedResult = await getPickedFlattenKeysForHookEntry(event);
+export default async (params: HookParams) => {
+  const pickedFlattedResult = await getPickedFlattenKeysForHookEntry(params);
   if (typeof pickedFlattedResult === 'undefined') {
     return;
   }

--- a/server/src/models/plugin/hook-params.ts
+++ b/server/src/models/plugin/hook-params.ts
@@ -1,0 +1,7 @@
+import type { Context } from '@strapi/types/dist/modules/documents/middleware';
+
+export type HookParams = {
+  context: Context;
+  documentId: string;
+  locale: string;
+};

--- a/server/src/register.ts
+++ b/server/src/register.ts
@@ -1,7 +1,56 @@
 import type { Core } from '@strapi/strapi';
+import type { Context } from '@strapi/types/dist/modules/documents/middleware';
+import uploadEventEntryToLocalazyHook from './lifecycles/upload-event-entry-to-localazy-hook';
+import deprecateEventEntryInLocalazyHook from './lifecycles/deprecate-event-entry-in-localazy-hook';
 
 const register = ({ strapi }: { strapi: Core.Strapi }) => {
-  // register phase
+  strapi.documents.use(async (context: Context, next) => {
+    let result;
+    switch (context.action) {
+      case 'create':
+      case 'update':
+        try {
+          result = await next();
+
+          const hookResult = await uploadEventEntryToLocalazyHook({
+            context,
+            documentId: result.documentId,
+            locale: context.params.locale || context['locale'],
+          });
+          if (typeof hookResult !== 'undefined') {
+            strapi.log.info(`${context.action} hook result: ${JSON.stringify(hookResult)}`);
+          }
+        } catch (e) {
+          strapi.log.error(e);
+        } finally {
+          break;
+        }
+      case 'delete': {
+        try {
+          const hookResult = await deprecateEventEntryInLocalazyHook({
+            context,
+            documentId: context.params.documentId,
+            locale: context.params.locale || context['locale'],
+          });
+          if (typeof hookResult !== 'undefined') {
+            strapi.log.info(`${context.action} hook result: ${JSON.stringify(hookResult)}`);
+          }
+          result = await next();
+        } catch (e) {
+          strapi.log.error(e);
+        } finally {
+          break;
+        }
+      }
+      default:
+        result = await next();
+        break;
+    }
+
+    // Modify the result as necessary before returning it
+
+    return result;
+  });
 };
 
 export default register;


### PR DESCRIPTION
- Removed the RequestInitiatorHelper from the bootstrap phase to streamline event handling.
- Updated the register phase to include new lifecycle hooks for create, update, and delete actions, enhancing integration with Localazy.
- Refactored the upload and deprecate hooks to accept a unified HookParams type, improving type safety and clarity.
- Adjusted the get-picked-flatten-keys utility to work with the new HookParams structure, ensuring consistent handling of document actions.
- Enhanced logging for lifecycle events to provide better insights during operations.