### PR TITLE
LOC-2904 - Fix Failing Strapi Transfer Command With Plugin Installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ localazy: {
        */
       populateDefaultDepth?: number, // default is 5
       populateMaxDepth?: number, // default is 10
+      skipCreatorFields?: boolean, // default is false
+      enableSocketIO?: boolean, // default is true
     },
   },
 ```

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -2,6 +2,7 @@ import type { Core } from '@strapi/strapi';
 import deepPopulateHook, { DeepPopulateHookEvent } from './lifecycles/deep-populate-hook';
 import { Server } from 'socket.io';
 import { WebSocketServer } from 'ws';
+import { PLUGIN_NAME } from './config/core/config';
 
 const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
   // bootstrap phase
@@ -18,18 +19,20 @@ const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
     }
   });
 
-  process.nextTick(async () => {
-    const io = new Server(strapi.server.httpServer, {
-      cors: {
-        origin: '*',
-        methods: ['GET', 'POST'],
-      },
-      // this must be a constructor
-      wsEngine: WebSocketServer,
-    });
+  if (strapi.plugin(PLUGIN_NAME)?.config('enableSocketIO', true)) {
+    process.nextTick(async () => {
+      const io = new Server(strapi.server.httpServer, {
+        cors: {
+          origin: '*',
+          methods: ['GET', 'POST'],
+        },
+        // this must be a constructor
+        wsEngine: WebSocketServer,
+      });
 
-    strapi.StrapIO = io;
-  });
+      strapi.StrapIO = io;
+    });
+  }
 };
 
 export default bootstrap;


### PR DESCRIPTION
✨ feat: Enhance README and bootstrap logic

- Added `skipCreatorFields` and `enableSocketIO` options to the README for better configuration clarity.
- Updated the bootstrap logic to conditionally initialize Socket.IO based on the `enableSocketIO` configuration option.