### PR TITLE
Update network calls to use custom Strapi path

### DIFF
--- a/admin/src/modules/@common/api/strapi-api-base.ts
+++ b/admin/src/modules/@common/api/strapi-api-base.ts
@@ -21,12 +21,13 @@ const createStrapiApiAxiosInstance = (baseUrl: string | null = null) => {
     baseUrl = `${BASE_PLUGIN_PATH}`;
   }
 
-  const instance = axios.create({
-    baseURL: `${baseUrl}`,
-  });
+  const instance = axios.create();
 
   instance.interceptors.request.use(
     async (config) => {
+      // Honors a custom admin URL/path so requests are scoped under it (e.g. `/cms/localazy/...`).
+      const backendURL = ((window.strapi as { backendURL?: string } | undefined)?.backendURL || '').replace(/\/$/, '');
+      config.baseURL = `${backendURL}${baseUrl}`;
       config.headers.set({
         Accept: 'application/json',
         'Content-Type': 'application/json',


### PR DESCRIPTION
This PR address an issue where the plugin fails make valid network calls when the Strapi instance served from a custom, non-root, path fails. It resolves this by prepending Strapi's `backendURL` (if it exists) to the `baseURL` when making internal network calls. This address https://github.com/localazy/strapi-plugin/issues/119