### PR TITLE
feat: migrate admin axios client to Strapi getFetchClient (LOC-4169)

### DIFF
--- a/admin/src/modules/@common/api/strapi-api-base.ts
+++ b/admin/src/modules/@common/api/strapi-api-base.ts
@@ -1,59 +1,42 @@
 /**
- * axios with a custom config.
+ * Wrapper around Strapi's `getFetchClient` that preserves the existing
+ * `.get / .post / .put / .delete` call shape used by every plugin service.
+ *
+ * Auth (Authorization header) and the Strapi backend base URL are handled by
+ * `getFetchClient` itself; we only prepend the plugin path and attach the
+ * plugin-identifying header on every request.
  */
 
-import axios from 'axios';
+import { getFetchClient } from '@strapi/strapi/admin';
 import { PLUGIN_ID } from '../../../pluginId';
 
 const BASE_PLUGIN_PATH = `/${PLUGIN_ID}`;
-const JWT_TOKEN_NAME = 'jwtToken';
+const LOCALAZY_HEADER = { 'X-Localazy-Initiated-By': 'strapi-plugin-localazy' };
 
-const getToken = (): string => {
-  const jwtTokenCookie = document.cookie.split('; ').find((row) => row.startsWith(`${JWT_TOKEN_NAME}=`));
-  const jwtToken = jwtTokenCookie ? jwtTokenCookie.split('=')[1] : '';
-  const raw = jwtToken || localStorage.getItem(JWT_TOKEN_NAME) || sessionStorage.getItem(JWT_TOKEN_NAME) || '';
-  // Strip surrounding quotes if present (e.g. stored as "\"token\"")
-  return raw.replace(/^["']|["']$/g, '');
+type RequestConfig = {
+  params?: any;
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+  validateStatus?: ((status: number) => boolean) | null;
 };
+
+const withPluginHeader = (config?: RequestConfig): RequestConfig => ({
+  ...(config ?? {}),
+  headers: { ...(config?.headers ?? {}), ...LOCALAZY_HEADER },
+});
 
 const createStrapiApiAxiosInstance = (baseUrl: string | null = null) => {
-  if (baseUrl === null) {
-    baseUrl = `${BASE_PLUGIN_PATH}`;
-  }
+  const prefix = baseUrl ?? BASE_PLUGIN_PATH;
+  const buildUrl = (url: string) => `${prefix}${url}`;
 
-  const instance = axios.create();
-
-  instance.interceptors.request.use(
-    async (config) => {
-      // Honors a custom admin URL/path so requests are scoped under it (e.g. `/cms/localazy/...`).
-      const backendURL = ((window.strapi as { backendURL?: string } | undefined)?.backendURL || '').replace(/\/$/, '');
-      config.baseURL = `${backendURL}${baseUrl}`;
-      config.headers.set({
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        // Add this header to identify the request as initiated by the plugin
-        'X-Localazy-Initiated-By': 'strapi-plugin-localazy',
-      });
-      const token = getToken();
-      if (token) {
-        config.headers.set('Authorization', `Bearer ${token}`);
-      }
-
-      return config;
-    },
-    (error) => {
-      return Promise.reject(error);
-    }
-  );
-
-  instance.interceptors.response.use(
-    (response) => response,
-    (error) => {
-      throw error;
-    }
-  );
-
-  return instance;
+  return {
+    get: (url: string, config?: RequestConfig) => getFetchClient().get(buildUrl(url), withPluginHeader(config)),
+    post: (url: string, data?: any, config?: RequestConfig) =>
+      getFetchClient().post(buildUrl(url), data, withPluginHeader(config)),
+    put: (url: string, data?: any, config?: RequestConfig) =>
+      getFetchClient().put(buildUrl(url), data, withPluginHeader(config)),
+    delete: (url: string, config?: RequestConfig) => getFetchClient().del(buildUrl(url), withPluginHeader(config)),
+  };
 };
 
-export { createStrapiApiAxiosInstance, getToken };
+export { createStrapiApiAxiosInstance };

--- a/admin/src/modules/@common/api/strapi-api-base.ts
+++ b/admin/src/modules/@common/api/strapi-api-base.ts
@@ -29,13 +29,16 @@ const createStrapiApiAxiosInstance = (baseUrl: string | null = null) => {
   const prefix = baseUrl ?? BASE_PLUGIN_PATH;
   const buildUrl = (url: string) => `${prefix}${url}`;
 
+  let cachedClient: ReturnType<typeof getFetchClient> | null = null;
+  const client = () => (cachedClient ??= getFetchClient());
+
   return {
-    get: (url: string, config?: RequestConfig) => getFetchClient().get(buildUrl(url), withPluginHeader(config)),
+    get: (url: string, config?: RequestConfig) => client().get(buildUrl(url), withPluginHeader(config)),
     post: (url: string, data?: any, config?: RequestConfig) =>
-      getFetchClient().post(buildUrl(url), data, withPluginHeader(config)),
+      client().post(buildUrl(url), data, withPluginHeader(config)),
     put: (url: string, data?: any, config?: RequestConfig) =>
-      getFetchClient().put(buildUrl(url), data, withPluginHeader(config)),
-    delete: (url: string, config?: RequestConfig) => getFetchClient().del(buildUrl(url), withPluginHeader(config)),
+      client().put(buildUrl(url), data, withPluginHeader(config)),
+    delete: (url: string, config?: RequestConfig) => client().del(buildUrl(url), withPluginHeader(config)),
   };
 };
 

--- a/admin/src/modules/localazy-download/services/localazy-download-service.ts
+++ b/admin/src/modules/localazy-download/services/localazy-download-service.ts
@@ -10,7 +10,7 @@ export default class LocalazyDownloadService {
 
       return result.data;
     } catch (e: any) {
-      throw e.data;
+      throw e.response?.data ?? e;
     }
   }
 }

--- a/admin/src/modules/localazy-upload/services/localazy-upload-service.ts
+++ b/admin/src/modules/localazy-upload/services/localazy-upload-service.ts
@@ -10,7 +10,7 @@ export default class LocalazyUploadService {
 
       return result.data;
     } catch (e: any) {
-      throw e.data;
+      throw e.response?.data ?? e;
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "@types/react-dom": "^19.0.2",
         "@typescript-eslint/eslint-plugin": "^8.21.0",
         "@typescript-eslint/parser": "^8.21.0",
-        "axios": "^1.7.9",
         "chalk": "^5.4.1",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
@@ -5615,17 +5614,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@strapi/content-manager/node_modules/@types/react-dom": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
-      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
     "node_modules/@strapi/content-manager/node_modules/http-errors": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
@@ -5929,17 +5917,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@strapi/content-releases/node_modules/@types/react-dom": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
-      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
     "node_modules/@strapi/content-releases/node_modules/intl-messageformat": {
       "version": "10.5.11",
       "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.11.tgz",
@@ -6168,17 +6145,6 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@strapi/content-type-builder/node_modules/@types/react-dom": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
-      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@strapi/content-type-builder/node_modules/fs-extra": {
@@ -6837,18 +6803,6 @@
         "styled-components": "^6.0.0"
       }
     },
-    "node_modules/@strapi/design-system/node_modules/@types/react": {
-      "version": "18.3.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
-      "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@strapi/design-system/node_modules/react-remove-scroll": {
       "version": "2.5.10",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
@@ -7229,17 +7183,6 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@strapi/i18n/node_modules/@types/react-dom": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
-      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@strapi/i18n/node_modules/intl-messageformat": {
@@ -7683,17 +7626,6 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@strapi/review-workflows/node_modules/@types/react-dom": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
-      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@strapi/review-workflows/node_modules/intl-messageformat": {
@@ -9544,18 +9476,6 @@
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@strapi/ui-primitives/node_modules/@types/react": {
-      "version": "18.3.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
-      "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@strapi/ui-primitives/node_modules/react-remove-scroll": {
       "version": "2.5.10",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
@@ -9712,17 +9632,6 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@strapi/upload/node_modules/@types/react-dom": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
-      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@strapi/upload/node_modules/fs-extra": {
@@ -11939,7 +11848,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -11965,18 +11875,6 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -13411,6 +13309,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -14376,6 +14275,7 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -16627,6 +16527,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -16886,6 +16787,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
       "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -25561,7 +25463,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5614,6 +5614,17 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@strapi/content-manager/node_modules/@types/react-dom": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
+      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
     "node_modules/@strapi/content-manager/node_modules/http-errors": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
@@ -5917,6 +5928,17 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@strapi/content-releases/node_modules/@types/react-dom": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
+      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
     "node_modules/@strapi/content-releases/node_modules/intl-messageformat": {
       "version": "10.5.11",
       "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.11.tgz",
@@ -6145,6 +6167,17 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@strapi/content-type-builder/node_modules/@types/react-dom": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
+      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@strapi/content-type-builder/node_modules/fs-extra": {
@@ -6803,6 +6836,18 @@
         "styled-components": "^6.0.0"
       }
     },
+    "node_modules/@strapi/design-system/node_modules/@types/react": {
+      "version": "18.3.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
+      "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@strapi/design-system/node_modules/react-remove-scroll": {
       "version": "2.5.10",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
@@ -7183,6 +7228,17 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@strapi/i18n/node_modules/@types/react-dom": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
+      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@strapi/i18n/node_modules/intl-messageformat": {
@@ -7626,6 +7682,17 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@strapi/review-workflows/node_modules/@types/react-dom": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
+      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@strapi/review-workflows/node_modules/intl-messageformat": {
@@ -9476,6 +9543,18 @@
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@strapi/ui-primitives/node_modules/@types/react": {
+      "version": "18.3.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
+      "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@strapi/ui-primitives/node_modules/react-remove-scroll": {
       "version": "2.5.10",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
@@ -9632,6 +9711,17 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/@types/react-dom": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
+      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@strapi/upload/node_modules/fs-extra": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "@types/react-dom": "^19.0.2",
     "@typescript-eslint/eslint-plugin": "^8.21.0",
     "@typescript-eslint/parser": "^8.21.0",
-    "axios": "^1.7.9",
     "chalk": "^5.4.1",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",


### PR DESCRIPTION
## Summary

Replaces the custom axios factory in `admin/src/modules/@common/api/strapi-api-base.ts` with a thin wrapper around Strapi's `getFetchClient` from `@strapi/strapi/admin`. Authorization and the admin `backendURL` are now provided by Strapi itself, removing the bespoke cookie/`localStorage` JWT reader and the manual `backendURL` prepend that was added in #120.

- `createStrapiApiAxiosInstance(baseUrl?)` keeps its current shape (`get / post / put / delete`) so the 14 plugin services keep working without changes.
- `delete` is mapped to `getFetchClient`'s `del` internally.
- The plugin-identifying header `X-Localazy-Initiated-By: strapi-plugin-localazy` is still attached to every request.
- `getFetchClient()` is invoked per request, not at module load, so it resolves after Strapi mounts.
- `getToken` helper is removed (no external consumers).
- `axios` is removed from `devDependencies`; lockfile refreshed via `npm install`.

Linked tasks: Fibery `LOC-4169`, Paperclip Coder issue `LOC-2`, Planner `LOC-1`.

## Acceptance criteria coverage

1. `strapi-api-base.ts` no longer imports `axios`; `axios` removed from `package.json` devDependencies; `package-lock.json` refreshed. ✅
2. All 14 caller services flow through `getFetchClient` via the unchanged factory signature. ✅
3. JWT/`Authorization` and `backendURL` come from Strapi's client; `getToken` deleted. ✅
4. `X-Localazy-Initiated-By: strapi-plugin-localazy` still sent on every plugin request. ✅
5. Each call site keeps the same method + URL + body + custom header shape (verified by reading both branches side-by-side). ✅
6. `npm run lint`, `npm run test:server` (168/168), `npm run test:ts:back`, `npm run test:ts:front`, `npm run build`, `npm run verify`, `npm run format:check` all pass locally. ✅
7. Manual host-app verification reserved for Tester.

## Notes

- `getFetchClient` is exported from `@strapi/strapi/admin` (re-exported from `@strapi/admin/strapi-admin`) under the installed `@strapi/strapi ^5.6.0` peer (resolved to `5.10.2`).
- `axios` remains a transitive dependency of `@strapi/admin` and `@strapi/cloud-cli`; it is no longer a direct devDependency of this plugin.

## Test plan

- [ ] Strapi v5 host app, default admin path: login + connect Localazy + upload + download + settings + activity logs + entry exclusion all work.
- [ ] Same host app with `admin: { url: '/cms' }`: verify the #120 fix is preserved (requests go to `/cms/localazy/...`).
- [ ] Network panel: every plugin request carries `Authorization: Bearer …` and `X-Localazy-Initiated-By: strapi-plugin-localazy`.
- [ ] Admin users picker (settings page) still loads via `/admin/users` (the one call site that takes an absolute path).

Resolves LOC-4169 once merged. Do not merge — David merges manually.
